### PR TITLE
chore: add Vultr Creator Program to README Getting paid section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Wanna make a contribution but don't know how? Check out the [how to contribute p
 
 - [Startup.jobs](https://startup.jobs/)
 
+- [Vultr Creator Program](https://docs.vultr.com/platform/vultr-creator-program)
+
 - [Draft.dev](https://github.com/draftdev/jobs)
 
 - [Draft.dev DevRel career](https://devrelcareers.com/)


### PR DESCRIPTION
The Vultr Creator Program invites developers, DevOps engineers, SREs, and architects to write production-grade tutorials and earn up to `$800` per submission.

Added a link to the program in the `Getting paid` section of the README.